### PR TITLE
Use react-is to check valid components

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "hoist-non-react-statics": "^3.0.1",
     "path-to-regexp": "^1.7.0",
     "query-string": "^6.2.0",
+    "react-is": "^16.5.2",
     "react-lifecycles-compat": "^3.0.4"
   },
   "devDependencies": {

--- a/src/routers/getScreenForRouteName.js
+++ b/src/routers/getScreenForRouteName.js
@@ -1,3 +1,5 @@
+import { isValidElementType } from 'react-is';
+
 import invariant from '../utils/invariant';
 
 /**
@@ -23,7 +25,7 @@ export default function getScreenForRouteName(routeConfigs, routeName) {
   if (typeof routeConfig.getScreen === 'function') {
     const screen = routeConfig.getScreen();
     invariant(
-      typeof screen === 'function',
+      isValidElementType(screen),
       `The getScreen defined for route '${routeName} didn't return a valid ` +
         'screen or navigator.\n\n' +
         'Please pass it like this:\n' +

--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -1,3 +1,5 @@
+import { isValidElementType } from 'react-is';
+
 import invariant from '../utils/invariant';
 
 /**
@@ -17,9 +19,7 @@ function validateRouteConfigMap(routeConfigs) {
 
     if (
       !screenComponent ||
-      (typeof screenComponent !== 'function' &&
-        typeof screenComponent !== 'string' &&
-        !routeConfig.getScreen)
+      (!isValidElementType(screenComponent) && !routeConfig.getScreen)
     ) {
       throw new Error(`The component for route '${routeName}' must be a React component. For example:
 


### PR DESCRIPTION
The current checks do not work when using things like React.forwardRef. This fixes it by using the react-is package that is made for those checks.

Tested that is works with React.forwardRef components and still fails on invalid components.