### PR TITLE
WIP: Specify default params in the params key in route config

### DIFF
--- a/example/.eslintrc
+++ b/example/.eslintrc
@@ -2,7 +2,7 @@
   "extends": "../.eslintrc",
 
   "settings": {
-    "import/core-modules": [ "expo", "@react-navigation/core" ]
+    "import/core-modules": [ "expo", "@react-navigation/core", "react-navigation-stack" ]
   },
 
   "rules": {

--- a/example/App.js
+++ b/example/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Expo from 'expo';
 import { FlatList, I18nManager } from 'react-native';
 import { createAppContainer } from '@react-navigation/native';
+
 import {
   Assets as StackAssets,
   createStackNavigator,
@@ -11,13 +12,13 @@ import { ListSection, Divider } from 'react-native-paper';
 import SimpleStack from './src/SimpleStack';
 import SimpleTabs from './src/SimpleTabs';
 
-// Comment the following two lines to stop using react-native-screens
-import { useScreens } from 'react-native-screens';
+// Comment/uncomment the following two lines to toggle react-native-screens
+// import { useScreens } from 'react-native-screens';
+// useScreens();
 
 // Uncomment the following line to force RTL. Requires closing and re-opening
 // your app after you first load it with this option enabled.
 I18nManager.forceRTL(false);
-// useScreens();
 
 const data = [
   { component: SimpleStack, title: 'Simple Stack', routeName: 'SimpleStack' },

--- a/example/App.js
+++ b/example/App.js
@@ -30,16 +30,6 @@ class Home extends React.Component {
     title: 'Examples',
   };
 
-  componentDidMount() {
-    // this.props.navigation.addListener('refocus', payload => {
-    //   console.log({ payload });
-    // })
-
-    // setTimeout(() => {
-    //   this.props.navigation.emit('refocus', {lol: true});
-    // }, 1000)
-  }
-
   _renderItem = ({ item }) => (
     <ListSection.Item
       title={item.title}
@@ -86,4 +76,5 @@ const Root = createStackNavigator(
 );
 
 const App = createAppContainer(Root);
+export default App;
 Expo.registerRootComponent(App);

--- a/example/App.js
+++ b/example/App.js
@@ -9,6 +9,7 @@ import {
 import { ListSection, Divider } from 'react-native-paper';
 
 import SimpleStack from './src/SimpleStack';
+import SimpleTabs from './src/SimpleTabs';
 
 // Comment the following two lines to stop using react-native-screens
 import { useScreens } from 'react-native-screens';
@@ -19,7 +20,8 @@ I18nManager.forceRTL(false);
 // useScreens();
 
 const data = [
-  { component: SimpleStack, title: 'Simple', routeName: 'SimpleStack' },
+  { component: SimpleStack, title: 'Simple Stack', routeName: 'SimpleStack' },
+  { component: SimpleTabs, title: 'Simple Tabs', routeName: 'SimpleTabs' },
 ];
 
 // Cache images

--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "react-native-paper": "2.0.0-alpha.4",
     "react-native-screens": "^1.0.0-alpha.9",
     "react-navigation-stack": "^1.0.0-alpha.23",
-    "react-navigation-tabs": "^1.0.0-alpha.3"
+    "react-navigation-tabs": "^1.0.0-alpha.4"
   },
   "devDependencies": {
     "babel-plugin-module-resolver": "^3.0.0",

--- a/example/src/SimpleStack.js
+++ b/example/src/SimpleStack.js
@@ -1,14 +1,6 @@
 import React from 'react';
-import {
-  Dimensions,
-  Button,
-  ScrollView,
-  TouchableOpacity,
-  View,
-  Text,
-} from 'react-native';
+import { Button, ScrollView, TouchableOpacity, View, Text } from 'react-native';
 import { MaterialIcons } from 'react-native-vector-icons';
-import { withNavigation } from '@react-navigation/core';
 import { createStackNavigator } from 'react-navigation-stack';
 
 const LOREM_PAGE_ONE = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse in lacus malesuada tellus bibendum fringilla. Integer suscipit suscipit erat, sed molestie eros. Nullam fermentum odio vel mauris pulvinar accumsan. Duis blandit id nulla ac euismod. Nunc nec convallis mauris. Proin sit amet malesuada orci. Aliquam blandit mattis nisi ut eleifend. Morbi blandit ante neque, eu tincidunt est interdum in. Mauris pellentesque euismod nulla. Mauris posuere egestas nulla, sit amet eleifend quam egestas at. Maecenas odio erat, auctor eu consectetur eu, vulputate nec arcu. Praesent in felis massa. Nunc fermentum, massa vitae ultricies dictum, est mi posuere eros, sit amet posuere mi ante ac nulla. Etiam odio libero, tempor sit amet sagittis sed, fermentum ac lorem. Donec dignissim fermentum velit, ac ultrices nulla tristique vel.

--- a/example/src/SimpleStack.js
+++ b/example/src/SimpleStack.js
@@ -54,7 +54,7 @@ class LoremScreen extends React.Component {
         }}
       >
         {this.props.navigation
-          .getParam('text', LOREM_PAGE_ONE)
+          .getParam('text')
           .split('\n')
           .map((p, i) => (
             <Text

--- a/example/src/SimpleTabs.js
+++ b/example/src/SimpleTabs.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { createBottomTabNavigator } from 'react-navigation-tabs';
+import { Button, Text, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+class Screen extends React.Component {
+  static navigationOptions = ({ navigation }) => ({
+    tabBarLabel: navigation.getParam('title'),
+    tabBarIcon: ({ focused, tintColor }) => (
+      <Feather size={25} name={navigation.getParam('icon')} color={tintColor} />
+    ),
+  });
+
+  render() {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Text>{JSON.stringify(this.props.navigation.state.params)}</Text>
+        <Button
+          title="Go back"
+          onPress={() => this.props.navigation.goBack(null)}
+        />
+      </View>
+    );
+  }
+}
+
+export default createBottomTabNavigator(
+  {
+    A: {
+      screen: Screen,
+      params: { title: 'First One', icon: 'activity' },
+    },
+    B: {
+      screen: Screen,
+      params: { title: 'Second One', icon: 'aperture' },
+    },
+  },
+  {
+    tabBarOptions: {
+      activeTintColor: '#000',
+      inactiveTintColor: '#eee',
+    },
+  }
+);

--- a/example/src/SimpleTabs.js
+++ b/example/src/SimpleTabs.js
@@ -6,7 +6,7 @@ import { Feather } from '@expo/vector-icons';
 class Screen extends React.Component {
   static navigationOptions = ({ navigation }) => ({
     tabBarLabel: navigation.getParam('title'),
-    tabBarIcon: ({ focused, tintColor }) => (
+    tabBarIcon: ({ tintColor }) => (
       <Feather size={25} name={navigation.getParam('icon')} color={tintColor} />
     ),
   });

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4444,10 +4444,10 @@ react-navigation-stack@^1.0.0-alpha.23:
   resolved "https://registry.yarnpkg.com/react-navigation-stack/-/react-navigation-stack-1.0.0-alpha.23.tgz#515e940b5e1f864a73a80be43cafae767f9ed3f5"
   integrity sha512-EhM9SIlWYeCC1f1Ju53AUVfTyY6HLJwuGMVcb/VeVT513fPgOijD4HlmOcAngkKNVMNOfhPuFgvngg9TM4vYOA==
 
-react-navigation-tabs@^1.0.0-alpha.3:
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/react-navigation-tabs/-/react-navigation-tabs-1.0.0-alpha.3.tgz#dae59e0a448cfa8e194fe3776b1659e117f3a39b"
-  integrity sha512-V1iMy4QFhiWuBaaUMgWOuuBe0xl+/LXwiSwl4ejRDGRiPP7JLiqxFfgIo77X0Ce9YN2FOqq4A8GB7d4ssJtQIw==
+react-navigation-tabs@^1.0.0-alpha.4:
+  version "1.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/react-navigation-tabs/-/react-navigation-tabs-1.0.0-alpha.4.tgz#321c8cc19d14268d343a830689c741bb94c6ba80"
+  integrity sha512-ng8sCJmcQj1ciWaj0eJudQvYng/oL24konNPNudSrMyVKAfKr4+HcRPLY/rol+efLJ8UGjXGv2qdRNkBNeaLew==
   dependencies:
     hoist-non-react-statics "^2.5.0"
     prop-types "^15.6.1"

--- a/src/getChildEventSubscriber.js
+++ b/src/getChildEventSubscriber.js
@@ -169,10 +169,12 @@ export default function getChildEventSubscriber(addListener, key) {
     },
     emit(eventName, payload) {
       if (eventName !== 'refocus') {
-        console.error(`navigation.emit only supports the 'refocus' event currently.`);
+        console.error(
+          `navigation.emit only supports the 'refocus' event currently.`
+        );
         return;
       }
       emit(eventName, payload);
-    }
+    },
   };
 }

--- a/src/getNavigation.js
+++ b/src/getNavigation.js
@@ -39,7 +39,7 @@ export default function getNavigation(
       };
     },
     dangerouslyGetParent: () => null,
-    _childrenNavigation: getChildrenNavigationCache(getCurrentNavigation())
+    _childrenNavigation: getChildrenNavigationCache(getCurrentNavigation()),
   };
 
   const actionCreators = {

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -435,7 +435,7 @@ export default (routeConfigs, stackConfig = {}) => {
           }
           const routes = [...state.routes];
           routes[routeIndex] = {
-            params: getParamsForRouteAndAction(action.routeName, action.params),
+            params: getParamsForRouteAndAction(action.routeName, action),
             // merge the child state in this order to allow params override
             ...childState,
             routeName: action.routeName,

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -84,7 +84,8 @@ export default (routeConfigs, stackConfig = {}) => {
         })
       );
     }
-    const params = (route.params || action.params || initialRouteParams) && {
+    const params = (routeConfigs[initialRouteName].params || route.params || action.params || initialRouteParams) && {
+      ...(routeConfigs[initialRouteName].params || {}),
       ...(route.params || {}),
       ...(action.params || {}),
       ...(initialRouteParams || {}),
@@ -102,6 +103,15 @@ export default (routeConfigs, stackConfig = {}) => {
       index: 0,
       routes: [route],
     };
+  }
+
+  function getParamsForRouteAndAction(routeName, action) {
+    let routeConfig = routeConfigs[routeName];
+    if (routeConfig && routeConfig.params) {
+      return { ...routeConfig.params, ...action.params };
+    } else {
+      return action.params;
+    }
   }
 
   const {

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -84,7 +84,10 @@ export default (routeConfigs, stackConfig = {}) => {
         })
       );
     }
-    const params = (routeConfigs[initialRouteName].params || route.params || action.params || initialRouteParams) && {
+    const params = (routeConfigs[initialRouteName].params ||
+      route.params ||
+      action.params ||
+      initialRouteParams) && {
       ...(routeConfigs[initialRouteName].params || {}),
       ...(route.params || {}),
       ...(action.params || {}),
@@ -254,11 +257,11 @@ export default (routeConfigs, stackConfig = {}) => {
         }
       }
 
-      // Handle explicit push navigation action. This must happen after the
-      // focused child router has had a chance to handle the action.
+      // Handle push and navigate actions. This must happen after the focused
+      // child router has had a chance to handle the action.
       if (
         behavesLikePushAction(action) &&
-        childRouters[action.routeName] !== undefined
+        childRouters[action.routeName] !== undefined // undefined means it's not a childRouter or a screen
       ) {
         const childRouter = childRouters[action.routeName];
         let route;
@@ -278,6 +281,7 @@ export default (routeConfigs, stackConfig = {}) => {
           }
         });
 
+        // An instance of this route exists already and we're dealing with a navigate action
         if (action.type !== StackActions.PUSH && lastRouteIndex !== -1) {
           // If index is unchanged and params are not being set, leave state identity intact
           if (state.index === lastRouteIndex && !action.params) {
@@ -311,18 +315,25 @@ export default (routeConfigs, stackConfig = {}) => {
         }
 
         if (childRouter) {
+          // Delegate to the child router with the given action, or init it
           const childAction =
-            action.action || NavigationActions.init({ params: action.params });
+            action.action ||
+            NavigationActions.init({
+              params: getParamsForRouteAndAction(action.routeName, action),
+            });
           route = {
-            params: action.params,
-            // merge the child state in this order to allow params override
+            params: getParamsForRouteAndAction(action.routeName, action),
+            // note(brentvatne): does it make sense to wipe out the params
+            // here? or even to add params at all? need more info about what
+            // this solves
             ...childRouter.getStateForAction(childAction),
             routeName: action.routeName,
             key: action.key || generateKey(),
           };
         } else {
+          // Create the route from scratch
           route = {
-            params: action.params,
+            params: getParamsForRouteAndAction(action.routeName, action),
             routeName: action.routeName,
             key: action.key || generateKey(),
           };
@@ -417,12 +428,14 @@ export default (routeConfigs, stackConfig = {}) => {
           if (childRouter) {
             const childAction =
               action.action ||
-              NavigationActions.init({ params: action.params });
+              NavigationActions.init({
+                params: getParamsForRouteAndAction(action.routeName, action),
+              });
             childState = childRouter.getStateForAction(childAction);
           }
           const routes = [...state.routes];
           routes[routeIndex] = {
-            params: action.params,
+            params: getParamsForRouteAndAction(action.routeName, action.params),
             // merge the child state in this order to allow params override
             ...childState,
             routeName: action.routeName,
@@ -483,13 +496,21 @@ export default (routeConfigs, stackConfig = {}) => {
             if (router) {
               const childAction =
                 newStackAction.action ||
-                NavigationActions.init({ params: newStackAction.params });
+                NavigationActions.init({
+                  params: getParamsForRouteAndAction(
+                    newStackAction.routeName,
+                    newStackAction
+                  ),
+                });
 
               childState = router.getStateForAction(childAction);
             }
 
             return {
-              params: newStackAction.params,
+              params: getParamsForRouteAndAction(
+                newStackAction.routeName,
+                newStackAction
+              ),
               ...childState,
               routeName: newStackAction.routeName,
               key: newStackAction.key || generateKey(),

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -43,6 +43,15 @@ export default (routeConfigs, config = {}) => {
     }
   });
 
+  function getParamsForRoute(routeName, params) {
+    let routeConfig = routeConfigs[routeName];
+    if (routeConfig && routeConfig.params) {
+      return { ...routeConfig.params, ...params };
+    } else {
+      return params;
+    }
+  }
+
   const {
     getPathAndParamsForRoute,
     getActionForPathAndParams,
@@ -56,8 +65,12 @@ export default (routeConfigs, config = {}) => {
   }
 
   function resetChildRoute(routeName) {
-    const params =
+    let initialParams =
       routeName === initialRouteName ? initialRouteParams : undefined;
+    // note(brentvatne): merging initialRouteParams *on top* of default params
+    // on the route seems incorrect but it's consistent with existing behavior
+    // in stackrouter
+    let params = getParamsForRoute(routeName, initialParams);
     const childRouter = childRouters[routeName];
     if (childRouter) {
       const childAction = NavigationActions.init();

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1284,7 +1284,7 @@ describe('StackRouter', () => {
           screen: FooScreen,
         },
       },
-      { initialRouteName: 'Bar', initialRouteParams: { foo: 'bar' } }
+      { initialRouteName: 'Foo', initialRouteParams: { foo: 'bar' } }
     );
     const state = router.getStateForAction({ type: NavigationActions.INIT });
     expect(state).toEqual({
@@ -1294,8 +1294,34 @@ describe('StackRouter', () => {
       routes: [
         {
           key: state && state.routes[0].key,
-          routeName: 'Bar',
+          routeName: 'Foo',
           params: { foo: 'bar' },
+        },
+      ],
+    });
+  });
+
+  test('params in route config are merged with initialRouteParams', () => {
+    const FooScreen = () => <div />;
+    const router = StackRouter(
+      {
+        Foo: {
+          screen: FooScreen,
+          params: { foo: 'not-bar', meaning: 42 }
+        },
+      },
+      { initialRouteName: 'Foo', initialRouteParams: { foo: 'bar' } }
+    );
+    const state = router.getStateForAction({ type: NavigationActions.INIT });
+    expect(state).toEqual({
+      index: 0,
+      isTransitioning: false,
+      key: 'StackRouterRoot',
+      routes: [
+        {
+          key: state && state.routes[0].key,
+          routeName: 'Foo',
+          params: { foo: 'bar', meaning: 42 },
         },
       ],
     });

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1307,7 +1307,7 @@ describe('StackRouter', () => {
       {
         Foo: {
           screen: FooScreen,
-          params: { foo: 'not-bar', meaning: 42 }
+          params: { foo: 'not-bar', meaning: 42 },
         },
       },
       { initialRouteName: 'Foo', initialRouteParams: { foo: 'bar' } }


### PR DESCRIPTION
```js
export default createBottomTabNavigator(
  {
    A: {
      screen: Screen,
      params: { title: 'First One', icon: 'activity' },
    },
    B: {
      screen: Screen,
      params: { title: 'Second One', icon: 'aperture' },
    },
  },
  {
    tabBarOptions: {
      activeTintColor: '#000',
      inactiveTintColor: '#eee',
    },
  }
);
```

I went for the name params instead of defaultParams or initialParams because it's consistent with how we use navigationOptions in the routeConfig. I think it is clear to people that these are default params. If that doesn't turn out to be the case then we can adjust by renaming both navigationOptions and params in the route config object to something that implies default more strongly.