### PR TITLE
Do not clear navigation child from cache while transitioning

### DIFF
--- a/src/getChildrenNavigationCache.js
+++ b/src/getChildrenNavigationCache.js
@@ -7,7 +7,7 @@ export default function getChildrenNavigationCache(navigation) {
     navigation._childrenNavigation || (navigation._childrenNavigation = {});
   let childKeys = navigation.state.routes.map(route => route.key);
   Object.keys(childrenNavigationCache).forEach(cacheKey => {
-    if (!childKeys.includes(cacheKey)) {
+    if (!childKeys.includes(cacheKey) && !navigation.state.isTransitioning) {
       delete childrenNavigationCache[cacheKey];
     }
   });


### PR DESCRIPTION
This commit adds an additional conditional check before deleting the
navigation child from the cache list. This is to prevent the child getting
deleted, when 'getChildNavigation' is called by it's parent.

Happens when navigating back from a child navigator to the root,
and inside 'onNavigationStateChange' the 'screenProps' is changed.

Fixes #5301.