### PR TITLE
prevent onRef callback be called twice on withNavigationFocus Components

### DIFF
--- a/src/views/withNavigation.js
+++ b/src/views/withNavigation.js
@@ -5,7 +5,7 @@ import NavigationContext from './NavigationContext';
 
 export default function withNavigation(
   Component,
-  config = { injectOnRef: true }
+  config = { forwardRef: true }
 ) {
   class ComponentWithNavigation extends React.Component {
     static displayName = `withNavigation(${Component.displayName ||
@@ -25,7 +25,7 @@ export default function withNavigation(
               <Component
                 {...this.props}
                 navigation={navigation}
-                ref={config.injectOnRef ? this.props.onRef : undefined}
+                ref={config.forwardRef ? this.props.onRef : undefined}
               />
             );
           }}

--- a/src/views/withNavigation.js
+++ b/src/views/withNavigation.js
@@ -3,7 +3,10 @@ import hoistStatics from 'hoist-non-react-statics';
 import invariant from '../utils/invariant';
 import NavigationContext from './NavigationContext';
 
-export default function withNavigation(Component, injectOnRef = true) {
+export default function withNavigation(
+  Component,
+  config = { injectOnRef: true }
+) {
   class ComponentWithNavigation extends React.Component {
     static displayName = `withNavigation(${Component.displayName ||
       Component.name})`;
@@ -22,7 +25,7 @@ export default function withNavigation(Component, injectOnRef = true) {
               <Component
                 {...this.props}
                 navigation={navigation}
-                ref={injectOnRef ? this.props.onRef : undefined}
+                ref={config.injectOnRef ? this.props.onRef : undefined}
               />
             );
           }}

--- a/src/views/withNavigation.js
+++ b/src/views/withNavigation.js
@@ -3,7 +3,7 @@ import hoistStatics from 'hoist-non-react-statics';
 import invariant from '../utils/invariant';
 import NavigationContext from './NavigationContext';
 
-export default function withNavigation(Component) {
+export default function withNavigation(Component, injectOnRef = true) {
   class ComponentWithNavigation extends React.Component {
     static displayName = `withNavigation(${Component.displayName ||
       Component.name})`;
@@ -22,7 +22,7 @@ export default function withNavigation(Component) {
               <Component
                 {...this.props}
                 navigation={navigation}
-                ref={this.props.onRef}
+                ref={injectOnRef ? this.props.onRef : undefined}
               />
             );
           }}

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -43,7 +43,7 @@ export default function withNavigationFocus(Component) {
   }
 
   return hoistStatics(
-    withNavigation(ComponentWithNavigationFocus, { injectOnRef: false }),
+    withNavigation(ComponentWithNavigationFocus, { forwardRef: false }),
     Component
   );
 }

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -48,5 +48,8 @@ export default function withNavigationFocus(Component) {
     }
   }
 
-  return hoistStatics(withNavigation(ComponentWithNavigationFocus), Component);
+  return hoistStatics(
+    withNavigation(ComponentWithNavigationFocus, false),
+    Component
+  );
 }

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
-import invariant from '../utils/invariant';
 import withNavigation from './withNavigation';
 
 export default function withNavigationFocus(Component) {

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -18,11 +18,6 @@ export default function withNavigationFocus(Component) {
 
     componentDidMount() {
       const { navigation } = this.props;
-      invariant(
-        !!navigation,
-        'withNavigationFocus can only be used on a view hierarchy of a navigator. The wrapped component is unable to get access to navigation from props or context.'
-      );
-
       this.subscriptions = [
         navigation.addListener('didFocus', () =>
           this.setState({ isFocused: true })

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -43,7 +43,7 @@ export default function withNavigationFocus(Component) {
   }
 
   return hoistStatics(
-    withNavigation(ComponentWithNavigationFocus, false),
+    withNavigation(ComponentWithNavigationFocus, { injectOnRef: false }),
     Component
   );
 }


### PR DESCRIPTION
add `injectOnRef` predicate setting to `withNavigation` function.  By default is working like always, not breaking API.
With this, `withNavigationFocus` disable onRef injection on nested withNavigation, preventing `onRef ` callback be called twice.
Will fix issue: https://github.com/react-navigation/react-navigation-core/issues/29
 