### PR TITLE
Don’t propagate RESET event from switch router to nested stack routers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,11 @@ module.exports = {
     return require('./routers/SwitchRouter').default;
   },
 
+  // RouterTypes
+  get RouterTypes() {
+    return require('./routers/RouterTypes.json');
+  },
+
   get createConfigGetter() {
     return require('./routers/createConfigGetter').default;
   },

--- a/src/routers/RouterTypes.json
+++ b/src/routers/RouterTypes.json
@@ -1,0 +1,4 @@
+{
+  "STACK": "STACK",
+  "SWITCH": "SWITCH"
+}

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -1,5 +1,6 @@
 import NavigationActions from '../NavigationActions';
 import StackActions from './StackActions';
+import RouterTypes from './RouterTypes.json';
 import createConfigGetter from './createConfigGetter';
 import getScreenForRouteName from './getScreenForRouteName';
 import StateUtils from '../StateUtils';
@@ -124,6 +125,8 @@ export default (routeConfigs, stackConfig = {}) => {
   } = createPathParser(childRouters, routeConfigs, stackConfig);
 
   return {
+    type: RouterTypes.STACK,
+
     childRouters,
 
     getComponentForState(state) {

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -4,6 +4,7 @@ import createConfigGetter from './createConfigGetter';
 
 import NavigationActions from '../NavigationActions';
 import StackActions from './StackActions';
+import RouterTypes from './RouterTypes.json';
 import validateRouteConfigMap from './validateRouteConfigMap';
 import { createPathParser } from './pathUtils';
 
@@ -141,6 +142,8 @@ export default (routeConfigs, config = {}) => {
   }
 
   return {
+    type: RouterTypes.SWITCH,
+
     childRouters,
 
     getActionCreators(route, stateKey) {
@@ -312,6 +315,13 @@ export default (routeConfigs, config = {}) => {
         }
         let childState = routes[i];
         if (childRouter) {
+          if (
+            childRouter.type === RouterTypes.STACK &&
+            action.type === StackActions.RESET
+          ) {
+            return false;
+          }
+
           childState = childRouter.getStateForAction(action, childState);
         }
         if (!childState) {


### PR DESCRIPTION
| software         | version
| ---------------- | -------
| react-navigation | 3.3.2
| react-navigation/core | 3.1.0
| react-native     | https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz

This pull request fixes the error `"There is no route defined for key..."` when you supply RESET event to your root StackRouter and it is passed down to one of your nested StackRouters.

Bug:
video: https://drive.google.com/file/d/1QJvZ_C47xLAfXpb6YJfwFQsT2XRSf5Mv/view
snack: https://snack.expo.io/@serhiipalash/test-react-navigation-reset
repo: https://github.com/serhiipalash/test-react-navigation-reset
screenshot:
![simulator screen shot - iphone 6s - 2019-03-08 at 14 32 51](https://user-images.githubusercontent.com/14208343/54028858-1e016180-41af-11e9-8857-8dad0e3895f9.png)

There is no sense to spread root StackRouter RESET event to all nested StackRouters. You can do like this only if all your StackRouters are isomorphic to each other (have the same routes and configs). In that case potentially your can raise event “Reset to HomeScreen” and your root StackRouter and all your nested StackRouters will fall back to their HomeScreen as they all have it. But if your nested stack routers are not isomorphic to your root stack router (more realistic case), there will be an error “There is no route defined for key HomeScreen” caused by some of them.

This pull request adds “type” property to StackRouter and SwitchRouter and prevents passing down RESET event from SwitchRouter to its nested StackRouters.

To test this fix
```
git clone https://github.com/serhiipalash/test-react-navigation-reset
cd test-react-navigation-reset
git checkout -b fix-reset-event-propagation
npm install
expo start -c
```
video: https://drive.google.com/file/d/1QtHU4SqC0KlTA_9Bn_SZyu08ol7JHaqD/view

P.S. I am not sure why, but the bug happens only when you dispatch RESET event from SwitchRouter screen. When you do the same on one of root StackRouter screens, everything works fine.

https://drive.google.com/file/d/11PcjeIVmEieVJ-Ccw03rKae0hRiIst_x/view


P.P.S @ericvicenti can you please review this pr? If you remember, you reviewed one of my pr for fixing navigation reseting https://github.com/react-navigation/react-navigation/pull/3593. 