### PR TITLE
Set default value “null” for “key” property in RESET action

### DIFF
--- a/src/routers/StackActions.js
+++ b/src/routers/StackActions.js
@@ -22,6 +22,7 @@ const push = payload => ({
 
 const reset = payload => ({
   type: RESET,
+  key: null,
   ...payload,
 });
 


### PR DESCRIPTION
This pr makes "key" property in RESET action optional as it is now in docs, by using `null` as its default value. 

For more info please check discussion here https://github.com/react-navigation/react-navigation-core/pull/43