### PR TITLE
fix: drop custom history logic for isFirstRouteInParent

### DIFF
--- a/src/getChildNavigation.js
+++ b/src/getChildNavigation.js
@@ -60,13 +60,8 @@ function getChildNavigation(navigation, childKey, getCurrentParentNavigation) {
   const parentNavigation = getCurrentParentNavigation();
 
   if (parentNavigation) {
-    isFirstRouteInParent = parentNavigation.routeKeyHistory
-      ? // For navigators such as switch/tab navigators, history is separate from routes
-        parentNavigation.routeKeyHistory.length
-        ? parentNavigation.routeKeyHistory.indexOf(childKey) === 0
-        : true
-      : // For stack navigator, list of routes is the same as the history
-        parentNavigation.state.routes.indexOf(childRoute) === 0;
+    isFirstRouteInParent =
+      parentNavigation.state.routes.indexOf(childRoute) === 0;
   }
 
   if (


### PR DESCRIPTION
As the naming suggests, this checks if route is the first one in parent. So probably doesn't make sense to check history.