### PR TITLE
fix: fixed Tab/SwitchRouter incorrectly switching children on "back"

### DIFF
--- a/src/routers/__tests__/SwitchRouter-test.js
+++ b/src/routers/__tests__/SwitchRouter-test.js
@@ -162,6 +162,77 @@ describe('SwitchRouter', () => {
     expect(getSubState(1).routeName).toEqual('A');
   });
 
+  it('handles pop and does not apply pop action to inactive child', () => {
+    const { navigateTo, pop, getSubState } = getRouterTestHelper(
+      getExampleRouter({
+        backBehavior: 'initialRoute',
+        resetOnBlur: false, // Don't erase the state of substack B when we switch back to A
+      })
+    );
+
+    expect(getSubState(1).routeName).toEqual('A');
+
+    navigateTo('B');
+    navigateTo('B2');
+    expect(getSubState(1).routeName).toEqual('B');
+    expect(getSubState(2).routeName).toEqual('B2');
+
+    navigateTo('A');
+    expect(getSubState(1).routeName).toEqual('A');
+
+    // The pop action should not switch to B. It should stay on A
+    pop();
+    expect(getSubState(1).routeName).toEqual('A');
+  });
+
+  it('handles popToTop and does not apply popToTop action to inactive child', () => {
+    const { navigateTo, popToTop, getSubState } = getRouterTestHelper(
+      getExampleRouter({
+        backBehavior: 'initialRoute',
+        resetOnBlur: false, // Don't erase the state of substack B when we switch back to A
+      })
+    );
+
+    expect(getSubState(1).routeName).toEqual('A');
+
+    navigateTo('B');
+    navigateTo('B2');
+    expect(getSubState(1).routeName).toEqual('B');
+    expect(getSubState(2).routeName).toEqual('B2');
+
+    navigateTo('A');
+    expect(getSubState(1).routeName).toEqual('A');
+
+    // The popToTop action should not switch to B. It should stay on A
+    popToTop();
+    expect(getSubState(1).routeName).toEqual('A');
+  });
+
+  it('handles back and does switch to inactive child with matching key', () => {
+    const { navigateTo, back, getSubState } = getRouterTestHelper(
+      getExampleRouter({
+        backBehavior: 'initialRoute',
+        resetOnBlur: false, // Don't erase the state of substack B when we switch back to A
+      })
+    );
+
+    expect(getSubState(1).routeName).toEqual('A');
+
+    navigateTo('B');
+    navigateTo('B2');
+    expect(getSubState(1).routeName).toEqual('B');
+    expect(getSubState(2).routeName).toEqual('B2');
+    const b2Key = getSubState(2).key;
+
+    navigateTo('A');
+    expect(getSubState(1).routeName).toEqual('A');
+
+    // The back action should switch to B and go back from B2 to B1
+    back(b2Key);
+    expect(getSubState(1).routeName).toEqual('B');
+    expect(getSubState(2).routeName).toEqual('B1');
+  });
+
   it('handles nested actions', () => {
     const { navigateTo, getSubState } = getRouterTestHelper(getExampleRouter());
 

--- a/src/routers/__tests__/SwitchRouter-test.js
+++ b/src/routers/__tests__/SwitchRouter-test.js
@@ -139,6 +139,29 @@ describe('SwitchRouter', () => {
     expect(getSubState(2).routeName).toEqual('B1');
   });
 
+  it('handles back and does not apply back action to inactive child', () => {
+    const { navigateTo, back, getSubState } = getRouterTestHelper(
+      getExampleRouter({
+        backBehavior: 'initialRoute',
+        resetOnBlur: false, // Don't erase the state of substack B when we switch back to A
+      })
+    );
+
+    expect(getSubState(1).routeName).toEqual('A');
+
+    navigateTo('B');
+    navigateTo('B2');
+    expect(getSubState(1).routeName).toEqual('B');
+    expect(getSubState(2).routeName).toEqual('B2');
+
+    navigateTo('A');
+    expect(getSubState(1).routeName).toEqual('A');
+
+    // The back action should not switch to B. It should stay on A
+    back({ key: null });
+    expect(getSubState(1).routeName).toEqual('A');
+  });
+
   it('handles nested actions', () => {
     const { navigateTo, getSubState } = getRouterTestHelper(getExampleRouter());
 

--- a/src/routers/__tests__/routerTestHelper.js
+++ b/src/routers/__tests__/routerTestHelper.js
@@ -1,5 +1,6 @@
 import * as NavigationActions from '../../NavigationActions';
 import * as SwitchActions from '../../routers/SwitchActions';
+import * as StackActions from '../../routers/StackActions';
 
 // A simple helper that makes it easier to write basic routing tests
 // We generally want to apply one action after the other and check router returns correct state
@@ -31,9 +32,20 @@ export const getRouterTestHelper = (router, initAction = defaultInitAction) => {
       ...otherActionAttributes,
     });
 
-  const back = () =>
+  const back = key =>
     applyAction({
       type: NavigationActions.BACK,
+      key,
+    });
+
+  const pop = () =>
+    applyAction({
+      type: StackActions.POP,
+    });
+
+  const popToTop = () =>
+    applyAction({
+      type: StackActions.POP_TO_TOP,
     });
 
   const getState = () => state;
@@ -42,7 +54,16 @@ export const getRouterTestHelper = (router, initAction = defaultInitAction) => {
     return getSubStateRecursive(state, level);
   };
 
-  return { applyAction, navigateTo, jumpTo, back, getState, getSubState };
+  return {
+    applyAction,
+    navigateTo,
+    jumpTo,
+    back,
+    pop,
+    popToTop,
+    getState,
+    getSubState,
+  };
 };
 
 const getSubStateRecursive = (state, level = 1) => {


### PR DESCRIPTION
## Motivation

When using TabRouter, this sequence of events would result in behaviour other than what's expected:

```
RootStack - StackRouter
|== Main (default) - Screen
|== TabbedPage - TabRouter
    |== A (default) - Screen
    |== B - StackRouter
         |== B1 - Screen
         |== B2 - Screen
```

Start at Main
1. Navigate to TabbedPage
2. Navigate to B (user taps tab B)
3. Navigate to B2 (user taps an item to open new stack entry)
4. Navigate to A (user taps tab A)
5. Press "back"

The user at this point would expect to go back to "Main"

Currently though, the user would go back to B1. This is because the Switch Navigator would see that a child can handle the action (which makes sense for `NAVIGATE` actions) and focus that. However, this doesn't make sense for `BACK` actions.

## Fix

I added 2 lines to explicitly not pass back actions to children, as well as a test for the case. The test fails on master, but passes on this branch.