### PR TITLE
fix: avoid error when updateNextStateHistory called with state

### DIFF
--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -82,7 +82,10 @@ export default (routeConfigs, config = {}) => {
 
   function getNextState(action, prevState, possibleNextState) {
     function updateNextStateHistory(prevState, nextState) {
-      if (backBehavior !== 'history' || nextState.index === prevState.index) {
+      if (
+        backBehavior !== 'history' ||
+        (prevState && nextState && nextState.index === prevState.index)
+      ) {
         return nextState;
       }
       let nextRouteKeyHistory = prevState ? prevState.routeKeyHistory : [];
@@ -104,6 +107,7 @@ export default (routeConfigs, config = {}) => {
     let nextState = possibleNextState;
     if (
       prevState &&
+      possibleNextState &&
       prevState.index !== possibleNextState.index &&
       resetOnBlur
     ) {

--- a/src/routers/__tests__/SwitchRouter-test.js
+++ b/src/routers/__tests__/SwitchRouter-test.js
@@ -231,6 +231,19 @@ describe('SwitchRouter', () => {
     navigateTo('Home');
     expect(getSubState(1).routeName).toEqual('Home');
   });
+
+  it('does not error for a nested navigate action in an uninitialized history router', () => {
+    const { navigateTo, getSubState } = getRouterTestHelper(
+      getExampleRouter({ backBehavior: 'history' }),
+      { skipInitializeState: true }
+    );
+
+    navigateTo('B', {
+      action: NavigationActions.navigate({ routeName: 'B2' }),
+    });
+    expect(getSubState(1).routeName).toEqual('B');
+    expect(getSubState(2).routeName).toEqual('B2');
+  });
 });
 
 const getExampleRouter = (config = {}) => {

--- a/src/routers/__tests__/routerTestHelper.js
+++ b/src/routers/__tests__/routerTestHelper.js
@@ -6,12 +6,15 @@ import * as SwitchActions from '../../routers/SwitchActions';
 // it's often convenient to manipulate a structure that keeps the router state to avoid
 // creating many state1, state2, state3 local variables which are prone to typos...
 
-const defaultInitAction = {
-  type: NavigationActions.INIT,
+const defaultOptions = {
+  skipInitializeState: false,
 };
 
-export const getRouterTestHelper = (router, initAction = defaultInitAction) => {
-  let state = router.getStateForAction(initAction);
+export const getRouterTestHelper = (router, options = defaultOptions) => {
+  let state =
+    options && options.skipInitializeState
+      ? undefined
+      : router.getStateForAction({ type: NavigationActions.INIT });
 
   const applyAction = action => {
     state = router.getStateForAction(action, state);


### PR DESCRIPTION
When I navigated to a SwitchRouter that hadn't been initialized yet and then immediately tried to navigate within it using a subaction, this would cause an error because I failed to check if prevState was populated. This fix checks that prevState exists in updateNextStateHistory.

This fixes an edge-case bug that I introduced in my last change - sorry!

I also added a test.