### PR TITLE
fix: update navigation prop invariant for v4

### DIFF
--- a/src/navigators/createNavigator.js
+++ b/src/navigators/createNavigator.js
@@ -24,7 +24,7 @@ function createNavigator(NavigatorView, router, navigationConfig) {
       const { navigation, screenProps } = nextProps;
       invariant(
         navigation != null,
-        'The navigation prop is missing for this navigator. In react-navigation 3 you must set up your app container directly. More info: https://reactnavigation.org/docs/en/app-containers.html'
+        'The navigation prop is missing for this navigator. In react-navigation v3 and v4 you must set up your app container directly. More info: https://reactnavigation.org/docs/en/app-containers.html'
       );
       const { state } = navigation;
       const { routes } = state;


### PR DESCRIPTION
Even if RN v4 use core v3, I find this would make this message less confusing for react-navigation v4 users